### PR TITLE
Try searching in path if can't locate direct path for cross compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-CC=/root/opt/cross/bin/i686-elf-gcc
+ifneq ("$(wildcard /root/opt/cross/bin/i686-elf-gcc)","")
+    CC = /root/opt/cross/bin/i686-elf-gcc
+else
+    CC = i686-elf-gcc
+endif
 COMPILER_ARGS=-I./h -g -ffreestanding -O2 -nostdlib -Wall -Wextra -Werror
 LINKER_ARGS=-lgcc
 SRCC=$(wildcard c/*.c)


### PR DESCRIPTION
I'm keeping my cross compiler under `/usr/bin` instead of the static path you hard coded. I think it is better the search compiler executable in path if it can't locate the path you specified.

```console
$ which i686-elf-gcc
/usr/bin/i686-elf-gcc
$ make -j8 
Using i686-elf-gcc
Using i686-elf-gcc
$ make clean
$ sudo touch /root/opt/cross/bin/i686-elf-gcc
$ sudo make -j8
Using /root/opt/cross/bin/i686-elf-gcc
```